### PR TITLE
Fix InvalidOperationException when _disableHttp2 is null

### DIFF
--- a/csharp/core/Client.cs
+++ b/csharp/core/Client.cs
@@ -2149,7 +2149,7 @@ namespace AlibabaCloud.OpenApiClient
                     {"period", AlibabaCloud.TeaUtil.Common.DefaultNumber(runtime.BackoffPeriod, 1)},
                 }},
                 {"ignoreSSL", runtime.IgnoreSSL},
-                {"disableHttp2", DefaultAny(_disableHttp2.Value, false)},
+                {"disableHttp2", DefaultAny(_disableHttp2, false)},
             };
 
             TeaRequest _lastRequest = null;
@@ -2327,7 +2327,7 @@ namespace AlibabaCloud.OpenApiClient
                     {"period", AlibabaCloud.TeaUtil.Common.DefaultNumber(runtime.BackoffPeriod, 1)},
                 }},
                 {"ignoreSSL", runtime.IgnoreSSL},
-                {"disableHttp2", DefaultAny(_disableHttp2.Value, false)},
+                {"disableHttp2", DefaultAny(_disableHttp2, false)},
             };
 
             TeaRequest _lastRequest = null;


### PR DESCRIPTION
Fix InvalidOperationException when _disableHttp2 is null.