### PR TITLE
fix: detect throttling by x-acs-retry-after header

### DIFF
--- a/cpp/src/Client.cpp
+++ b/cpp/src/Client.cpp
@@ -239,13 +239,14 @@ Darabonba::Json Client::doRPCRequest(const string &action, const string &version
         json err = json(_res);
         Darabonba::Json requestId = Darabonba::defaultVal(err.value("RequestId", Darabonba::Json()), err.value("requestId", Darabonba::Json()));
         Darabonba::Json code = Darabonba::defaultVal(err.value("Code", Darabonba::Json()), err.value("code", Darabonba::Json()));
-        if ((DARA_STRING_TEMPLATE("" , code) == "Throttling") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.User") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.Api")) {
+        int64_t retryAfter = Utils::Utils::getThrottlingTimeLeft(response_->getHeaders());
+        if (retryAfter >= 0) {
           throw ThrottlingException(json({
             {"statusCode" , response_->getStatusCode()},
             {"code" , DARA_STRING_TEMPLATE("" , code)},
             {"message" , DARA_STRING_TEMPLATE("code: " , response_->getStatusCode() , ", " , Darabonba::defaultVal(err.value("Message", Darabonba::Json()), err.value("message", Darabonba::Json())) , " request id: " , requestId)},
             {"description" , DARA_STRING_TEMPLATE("" , Darabonba::defaultVal(err.value("Description", Darabonba::Json()), err.value("description", Darabonba::Json())))},
-            {"retryAfter" , Utils::Utils::getThrottlingTimeLeft(response_->getHeaders())},
+            {"retryAfter" , retryAfter},
             {"data" , err},
             {"requestId" , DARA_STRING_TEMPLATE("" , requestId)}
           }));
@@ -474,13 +475,14 @@ Darabonba::Json Client::doROARequest(const string &action, const string &version
         string requestId = Darabonba::Convert::stringVal(Darabonba::defaultVal(err.value("RequestId", Darabonba::Json()), err.value("requestId", Darabonba::Json())));
         requestId = Darabonba::Convert::stringVal(Darabonba::defaultVal(requestId, err.value("requestid", Darabonba::Json())));
         string code = Darabonba::Convert::stringVal(Darabonba::defaultVal(err.value("Code", Darabonba::Json()), err.value("code", Darabonba::Json())));
-        if ((DARA_STRING_TEMPLATE("" , code) == "Throttling") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.User") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.Api")) {
+        int64_t retryAfter = Utils::Utils::getThrottlingTimeLeft(response_->getHeaders());
+        if (retryAfter >= 0) {
           throw ThrottlingException(json({
             {"statusCode" , response_->getStatusCode()},
             {"code" , DARA_STRING_TEMPLATE("" , code)},
             {"message" , DARA_STRING_TEMPLATE("code: " , response_->getStatusCode() , ", " , Darabonba::defaultVal(err.value("Message", Darabonba::Json()), err.value("message", Darabonba::Json())) , " request id: " , requestId)},
             {"description" , DARA_STRING_TEMPLATE("" , Darabonba::defaultVal(err.value("Description", Darabonba::Json()), err.value("description", Darabonba::Json())))},
-            {"retryAfter" , Utils::Utils::getThrottlingTimeLeft(response_->getHeaders())},
+            {"retryAfter" , retryAfter},
             {"data" , err},
             {"requestId" , DARA_STRING_TEMPLATE("" , requestId)}
           }));
@@ -709,13 +711,14 @@ Darabonba::Json Client::doROARequestWithForm(const string &action, const string 
         json err = json(_res);
         string requestId = Darabonba::Convert::stringVal(Darabonba::defaultVal(err.value("RequestId", Darabonba::Json()), err.value("requestId", Darabonba::Json())));
         string code = Darabonba::Convert::stringVal(Darabonba::defaultVal(err.value("Code", Darabonba::Json()), err.value("code", Darabonba::Json())));
-        if ((DARA_STRING_TEMPLATE("" , code) == "Throttling") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.User") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.Api")) {
+        int64_t retryAfter = Utils::Utils::getThrottlingTimeLeft(response_->getHeaders());
+        if (retryAfter >= 0) {
           throw ThrottlingException(json({
             {"statusCode" , response_->getStatusCode()},
             {"code" , DARA_STRING_TEMPLATE("" , code)},
             {"message" , DARA_STRING_TEMPLATE("code: " , response_->getStatusCode() , ", " , Darabonba::defaultVal(err.value("Message", Darabonba::Json()), err.value("message", Darabonba::Json())) , " request id: " , requestId)},
             {"description" , DARA_STRING_TEMPLATE("" , Darabonba::defaultVal(err.value("Description", Darabonba::Json()), err.value("description", Darabonba::Json())))},
-            {"retryAfter" , Utils::Utils::getThrottlingTimeLeft(response_->getHeaders())},
+            {"retryAfter" , retryAfter},
             {"data" , err},
             {"requestId" , DARA_STRING_TEMPLATE("" , requestId)}
           }));
@@ -969,13 +972,14 @@ Darabonba::Json Client::doRequest(const Params &params, const OpenApiRequest &re
 
         string requestId = Darabonba::Convert::stringVal(Darabonba::defaultVal(err.value("RequestId", Darabonba::Json()), err.value("requestId", Darabonba::Json())));
         string code = Darabonba::Convert::stringVal(Darabonba::defaultVal(err.value("Code", Darabonba::Json()), err.value("code", Darabonba::Json())));
-        if ((DARA_STRING_TEMPLATE("" , code) == "Throttling") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.User") || (DARA_STRING_TEMPLATE("" , code) == "Throttling.Api")) {
+        int64_t retryAfter = Utils::Utils::getThrottlingTimeLeft(response_->getHeaders());
+        if (retryAfter >= 0) {
           throw ThrottlingException(json({
             {"statusCode" , response_->getStatusCode()},
             {"code" , DARA_STRING_TEMPLATE("" , code)},
             {"message" , DARA_STRING_TEMPLATE("code: " , response_->getStatusCode() , ", " , Darabonba::defaultVal(err.value("Message", Darabonba::Json()), err.value("message", Darabonba::Json())) , " request id: " , requestId)},
             {"description" , DARA_STRING_TEMPLATE("" , Darabonba::defaultVal(err.value("Description", Darabonba::Json()), err.value("description", Darabonba::Json())))},
-            {"retryAfter" , Utils::Utils::getThrottlingTimeLeft(response_->getHeaders())},
+            {"retryAfter" , retryAfter},
             {"data" , err},
             {"requestId" , DARA_STRING_TEMPLATE("" , requestId)}
           }));

--- a/cpp/src/Utils.cpp
+++ b/cpp/src/Utils.cpp
@@ -202,7 +202,13 @@ int64_t Utils::getThrottlingTimeLeft(const map<string, string> &headers) {
     return -1;
   }
   try {
-    return stoll(it->second);
+    int64_t timeLeft = stoll(it->second);
+    // Only a positive wait time is valid; missing/empty/invalid/<=0 → -1
+    // so callers' >= 0 check won't treat 0 as a usable backoff.
+    if (timeLeft <= 0) {
+      return -1;
+    }
+    return timeLeft;
   } catch (...) {
     return -1;
   }

--- a/cpp/src/Utils.cpp
+++ b/cpp/src/Utils.cpp
@@ -197,21 +197,15 @@ string Utils::getEndpoint(const string &endpoint, const bool &serverUse, const s
  * @return time left
  */
 int64_t Utils::getThrottlingTimeLeft(const map<string, string> &headers) {
-  auto it1 = headers.find("x-ratelimit-user-api");
-  auto it2 = headers.find("x-ratelimit-user");
-  
-  int64_t timeLeft1 = 0;
-  int64_t timeLeft2 = 0;
-  
-  if (it1 != headers.end()) {
-    timeLeft1 = getTimeLeft(it1->second);
+  auto it = headers.find("x-acs-retry-after");
+  if (it == headers.end() || it->second.empty()) {
+    return -1;
   }
-  
-  if (it2 != headers.end()) {
-    timeLeft2 = getTimeLeft(it2->second);
+  try {
+    return stoll(it->second);
+  } catch (...) {
+    return -1;
   }
-  
-  return max(timeLeft1, timeLeft2);
 }
 
 /**

--- a/cpp/src/Utils.cpp
+++ b/cpp/src/Utils.cpp
@@ -75,45 +75,6 @@ static void flattenMap(const json &obj, map<string, string> &result, const strin
   }
 }
 
-// Helper function to get time left from rate limit header
-static int64_t getTimeLeft(const string &rateLimit) {
-  if (rateLimit.empty()) {
-    return 0;
-  }
-
-  vector<string> pairs;
-  size_t start = 0;
-  size_t end = rateLimit.find(',');
-  while (end != string::npos) {
-    pairs.push_back(rateLimit.substr(start, end - start));
-    start = end + 1;
-    end = rateLimit.find(',', start);
-  }
-  pairs.push_back(rateLimit.substr(start));
-
-  for (const auto &pair : pairs) {
-    size_t colonPos = pair.find(':');
-    if (colonPos != string::npos) {
-      string key = pair.substr(0, colonPos);
-      string value = pair.substr(colonPos + 1);
-      // Trim whitespace
-      key.erase(0, key.find_first_not_of(" \t\n\r"));
-      key.erase(key.find_last_not_of(" \t\n\r") + 1);
-      value.erase(0, value.find_first_not_of(" \t\n\r"));
-      value.erase(value.find_last_not_of(" \t\n\r") + 1);
-
-      if (key == "TimeLeft") {
-        try {
-          return stoll(value);
-        } catch (...) {
-          return 0;
-        }
-      }
-    }
-  }
-  return 0;
-}
-
 // Helper function to filter out Stream types from JSON
 static json exceptStream(const json &obj) {
   if (obj.is_array()) {

--- a/cpp/tests/test_utils.cpp
+++ b/cpp/tests/test_utils.cpp
@@ -30,34 +30,28 @@ TEST(UtilsTest, GetEndpoint) {
 // Test GetThrottlingTimeLeft
 TEST(UtilsTest, GetThrottlingTimeLeft) {
   map<string, string> headers1;
-  headers1["x-ratelimit-user-api"] = "";
-  headers1["x-ratelimit-user"] = "";
   int64_t timeLeft1 = Utils::getThrottlingTimeLeft(headers1);
-  EXPECT_EQ(0, timeLeft1);
+  EXPECT_EQ(-1, timeLeft1);
 
   map<string, string> headers2;
-  headers2["x-ratelimit-user-api"] = "";
-  headers2["x-ratelimit-user"] = "Limit:1,Remain:0,TimeLeft:2000,Reset:1234";
+  headers2["x-acs-retry-after"] = "2000";
   int64_t timeLeft2 = Utils::getThrottlingTimeLeft(headers2);
   EXPECT_EQ(2000, timeLeft2);
 
   map<string, string> headers3;
-  headers3["x-ratelimit-user-api"] = "Limit:1,Remain:0,TimeLeft:2000,Reset:1234";
-  headers3["x-ratelimit-user"] = "";
+  headers3["x-acs-retry-after"] = "0";
   int64_t timeLeft3 = Utils::getThrottlingTimeLeft(headers3);
-  EXPECT_EQ(2000, timeLeft3);
+  EXPECT_EQ(0, timeLeft3);
 
   map<string, string> headers4;
-  headers4["x-ratelimit-user-api"] = "Limit:1,Remain:0,TimeLeft:2000,Reset:1234";
-  headers4["x-ratelimit-user"] = "Limit:1,Remain:0,TimeLeft:0,Reset:1234";
+  headers4["x-acs-retry-after"] = "invalid";
   int64_t timeLeft4 = Utils::getThrottlingTimeLeft(headers4);
-  EXPECT_EQ(2000, timeLeft4);
+  EXPECT_EQ(-1, timeLeft4);
 
   map<string, string> headers5;
-  headers5["x-ratelimit-user-api"] = "Limit:1,Remain:0,TimeLeft:0,Reset:1234";
-  headers5["x-ratelimit-user"] = "Limit:1,Remain:0,TimeLeft:0,Reset:1234";
+  headers5["x-acs-retry-after"] = "";
   int64_t timeLeft5 = Utils::getThrottlingTimeLeft(headers5);
-  EXPECT_EQ(0, timeLeft5);
+  EXPECT_EQ(-1, timeLeft5);
 }
 
 // Test Hash

--- a/cpp/tests/test_utils.cpp
+++ b/cpp/tests/test_utils.cpp
@@ -41,7 +41,7 @@ TEST(UtilsTest, GetThrottlingTimeLeft) {
   map<string, string> headers3;
   headers3["x-acs-retry-after"] = "0";
   int64_t timeLeft3 = Utils::getThrottlingTimeLeft(headers3);
-  EXPECT_EQ(0, timeLeft3);
+  EXPECT_EQ(-1, timeLeft3);
 
   map<string, string> headers4;
   headers4["x-acs-retry-after"] = "invalid";
@@ -52,6 +52,11 @@ TEST(UtilsTest, GetThrottlingTimeLeft) {
   headers5["x-acs-retry-after"] = "";
   int64_t timeLeft5 = Utils::getThrottlingTimeLeft(headers5);
   EXPECT_EQ(-1, timeLeft5);
+
+  map<string, string> headers6;
+  headers6["x-acs-retry-after"] = "-5";
+  int64_t timeLeft6 = Utils::getThrottlingTimeLeft(headers6);
+  EXPECT_EQ(-1, timeLeft6);
 }
 
 // Test Hash

--- a/csharp/OpenApiClientUnitTests/UtilsThrottlingTest.cs
+++ b/csharp/OpenApiClientUnitTests/UtilsThrottlingTest.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using AlibabaCloud.OpenApiClient;
+using Xunit;
+
+namespace OpenApiClientUnitTests
+{
+    public class UtilsThrottlingTest
+    {
+        [Fact]
+        public void GetThrottlingTimeLeft_OnlyPositiveWaitTimes()
+        {
+            Assert.Equal(2000L, Utils.GetThrottlingTimeLeft(new Dictionary<string, string>
+            {
+                { "x-acs-retry-after", "2000" }
+            }));
+            Assert.Null(Utils.GetThrottlingTimeLeft(new Dictionary<string, string>
+            {
+                { "x-acs-retry-after", "0" }
+            }));
+            Assert.Null(Utils.GetThrottlingTimeLeft(new Dictionary<string, string>
+            {
+                { "x-acs-retry-after", "" }
+            }));
+            Assert.Null(Utils.GetThrottlingTimeLeft(new Dictionary<string, string>
+            {
+                { "x-acs-retry-after", "-1" }
+            }));
+            Assert.Null(Utils.GetThrottlingTimeLeft(new Dictionary<string, string>
+            {
+                { "x-acs-retry-after", "invalid" }
+            }));
+            Assert.Null(Utils.GetThrottlingTimeLeft(new Dictionary<string, string>()));
+        }
+    }
+}

--- a/csharp/core/Client.cs
+++ b/csharp/core/Client.cs
@@ -356,7 +356,8 @@ namespace AlibabaCloud.OpenApiClient
                         Dictionary<string, object> err = (Dictionary<string, object>)(_res);
                         object requestId = Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         object code = Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -365,7 +366,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -702,7 +703,8 @@ namespace AlibabaCloud.OpenApiClient
                         Dictionary<string, object> err = (Dictionary<string, object>)(_res);
                         object requestId = Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         object code = Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -711,7 +713,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -1028,7 +1030,8 @@ namespace AlibabaCloud.OpenApiClient
                         string requestId = (string)Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         requestId = (string)Darabonba.Core.GetDefaultValue(requestId, err.Get("requestid"));
                         string code = (string)Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -1037,7 +1040,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -1354,7 +1357,8 @@ namespace AlibabaCloud.OpenApiClient
                         string requestId = (string)Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         requestId = (string)Darabonba.Core.GetDefaultValue(requestId, err.Get("requestid"));
                         string code = (string)Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -1363,7 +1367,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -1680,7 +1684,8 @@ namespace AlibabaCloud.OpenApiClient
                         Dictionary<string, object> err = (Dictionary<string, object>)(_res);
                         string requestId = (string)Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         string code = (string)Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -1689,7 +1694,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -2006,7 +2011,8 @@ namespace AlibabaCloud.OpenApiClient
                         Dictionary<string, object> err = (Dictionary<string, object>)(_res);
                         string requestId = (string)Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         string code = (string)Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -2015,7 +2021,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -2380,7 +2386,8 @@ namespace AlibabaCloud.OpenApiClient
                         }
                         string requestId = (string)Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         string code = (string)Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -2389,7 +2396,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };
@@ -2756,7 +2763,8 @@ namespace AlibabaCloud.OpenApiClient
                         }
                         string requestId = (string)Darabonba.Core.GetDefaultValue(err.Get("RequestId"), err.Get("requestId"));
                         string code = (string)Darabonba.Core.GetDefaultValue(err.Get("Code"), err.Get("code"));
-                        if (("" + code).Contains("Throttling"))
+                        long? retryAfter = Utils.GetThrottlingTimeLeft(response_.Headers);
+                        if (retryAfter != null)
                         {
                             throw new ThrottlingException
                             {
@@ -2765,7 +2773,7 @@ namespace AlibabaCloud.OpenApiClient
                                 Message = "code: " + response_.StatusCode + ", " + Darabonba.Core.GetDefaultValue(err.Get("Message"), err.Get("message")) + " request id: " + requestId,
                                 Detail = "" + Darabonba.Core.GetDefaultValue(err.Get("Detail"), err.Get("detail")),
                                 Description = "" + Darabonba.Core.GetDefaultValue(err.Get("Description"), err.Get("description")),
-                                RetryAfter = Utils.GetThrottlingTimeLeft(response_.Headers),
+                                RetryAfter = retryAfter,
                                 Data = err,
                                 RequestId = "" + requestId,
                             };

--- a/csharp/core/Utils.cs
+++ b/csharp/core/Utils.cs
@@ -183,8 +183,14 @@ namespace AlibabaCloud.OpenApiClient
         public static long? GetThrottlingTimeLeft(Dictionary<string, string> headers)
         {
             string retryAfter = headers.ContainsKey("x-acs-retry-after") ? headers["x-acs-retry-after"] : null;
+            if (string.IsNullOrEmpty(retryAfter))
+            {
+                return null;
+            }
             long timeLeftValue;
-            if (!long.TryParse(retryAfter, out timeLeftValue))
+            // Only a positive wait time is valid; missing/empty/invalid/<=0 → null
+            // so callers' null check won't treat 0 as a usable backoff.
+            if (!long.TryParse(retryAfter, out timeLeftValue) || timeLeftValue <= 0)
             {
                 return null;
             }

--- a/golang/client/client.go
+++ b/golang/client/client.go
@@ -1785,18 +1785,20 @@ func doRPCRequest_opResponse(response_ *dara.Response, client *Client, bodyType 
 		err := dara.ToMap(_res)
 		requestId := dara.Default(err["RequestId"], err["requestId"])
 		code := dara.Default(err["Code"], err["code"])
-		if strings.Contains(dara.ToString(code), "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(dara.ToString(code)),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + dara.ToString(requestId)),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(dara.ToString(requestId)),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,
@@ -1915,18 +1917,20 @@ func doROARequest_opResponse(response_ *dara.Response, client *Client, bodyType 
 		requestId := dara.ToString(dara.Default(err["RequestId"], err["requestId"]))
 		requestId = dara.ToString(dara.Default(requestId, err["requestid"]))
 		code := dara.ToString(dara.Default(err["Code"], err["code"]))
-		if strings.Contains(code, "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(code),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + requestId),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(requestId),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,
@@ -2044,18 +2048,20 @@ func doROARequestWithForm_opResponse(response_ *dara.Response, client *Client, b
 		err := dara.ToMap(_res)
 		requestId := dara.ToString(dara.Default(err["RequestId"], err["requestId"]))
 		code := dara.ToString(dara.Default(err["Code"], err["code"]))
-		if strings.Contains(code, "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(code),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + requestId),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(requestId),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,
@@ -2177,18 +2183,20 @@ func doRequest_opResponse(response_ *dara.Response, client *Client, params *open
 
 		requestId := dara.ToString(dara.Default(err["RequestId"], err["requestId"]))
 		code := dara.ToString(dara.Default(err["Code"], err["code"]))
-		if strings.Contains(code, "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(code),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + requestId),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(requestId),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,

--- a/golang/client/client_context_func.go
+++ b/golang/client/client_context_func.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 
 	spi "github.com/alibabacloud-go/alibabacloud-gateway-spi/client"
 	openapiutil "github.com/alibabacloud-go/darabonba-openapi/v2/utils"
@@ -1497,18 +1496,20 @@ func doRPCRequestWithCtx_opResponse(response_ *dara.Response, client *Client, bo
 		err := dara.ToMap(_res)
 		requestId := dara.Default(err["RequestId"], err["requestId"])
 		code := dara.Default(err["Code"], err["code"])
-		if strings.Contains(dara.ToString(code), "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(dara.ToString(code)),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + dara.ToString(requestId)),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(dara.ToString(requestId)),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,
@@ -1627,18 +1628,20 @@ func doROARequestWithCtx_opResponse(response_ *dara.Response, client *Client, bo
 		requestId := dara.ToString(dara.Default(err["RequestId"], err["requestId"]))
 		requestId = dara.ToString(dara.Default(requestId, err["requestid"]))
 		code := dara.ToString(dara.Default(err["Code"], err["code"]))
-		if strings.Contains(code, "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(code),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + requestId),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(requestId),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,
@@ -1756,18 +1759,20 @@ func doROAFormRequestWithCtx_opResponse(response_ *dara.Response, client *Client
 		err := dara.ToMap(_res)
 		requestId := dara.ToString(dara.Default(err["RequestId"], err["requestId"]))
 		code := dara.ToString(dara.Default(err["Code"], err["code"]))
-		if strings.Contains(code, "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(code),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + requestId),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(requestId),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,
@@ -1889,18 +1894,20 @@ func doRequestWithCtx_opResponse(response_ *dara.Response, client *Client, param
 
 		requestId := dara.ToString(dara.Default(err["RequestId"], err["requestId"]))
 		code := dara.ToString(dara.Default(err["Code"], err["code"]))
-		if strings.Contains(code, "Throttling") {
+		retryAfter := openapiutil.GetThrottlingTimeLeft(response_.Headers)
+		if !dara.IsNil(retryAfter) {
 			_err = &ThrottlingError{
 				StatusCode:  response_.StatusCode,
 				Code:        dara.String(code),
 				Message:     dara.String("code: " + dara.ToString(dara.IntValue(response_.StatusCode)) + ", " + dara.ToString(dara.Default(err["Message"], err["message"])) + " request id: " + requestId),
 				Detail:      dara.String(dara.ToString(dara.Default(err["Detail"], err["detail"]))),
 				Description: dara.String(dara.ToString(dara.Default(err["Description"], err["description"]))),
-				RetryAfter:  openapiutil.GetThrottlingTimeLeft(response_.Headers),
+				RetryAfter:  retryAfter,
 				Data:        err,
 				RequestId:   dara.String(requestId),
 			}
 			return _result, _err
+
 		} else if (dara.IntValue(response_.StatusCode) >= 400) && (dara.IntValue(response_.StatusCode) < 500) {
 			_err = &ClientError{
 				StatusCode:         response_.StatusCode,

--- a/golang/client/client_test.go
+++ b/golang/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -70,6 +71,29 @@ func (mock *throttlingMockHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 
 	responseBody := "{\"RequestId\":\"A45EE076-334D-5012-9746-A8F828D20FD4\",\"Quotas\":[]}"
 	w.WriteHeader(200)
+	w.Write([]byte(responseBody))
+}
+
+// errorCode is optional; when empty defaults to Throttling.
+type retryAfterOnlyMockHandler struct {
+	errorCode    string
+	retryAfterMS int
+	withHeader   bool
+	requestCount int
+}
+
+func (mock *retryAfterOnlyMockHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	mock.requestCount++
+	w.Header().Set("x-acs-request-id", "A45EE076-334D-5012-9746-A8F828D20FD4")
+	if mock.withHeader {
+		w.Header().Set("x-acs-retry-after", strconv.Itoa(mock.retryAfterMS))
+	}
+	code := mock.errorCode
+	if code == "" {
+		code = "Throttling"
+	}
+	responseBody := fmt.Sprintf(`{"Code":"%s","Message":"denied","RequestId":"A45EE076-334D-5012-9746-A8F828D20FD4"}`, code)
+	w.WriteHeader(400)
 	w.Write([]byte(responseBody))
 }
 
@@ -1853,4 +1877,298 @@ func TestThrottlingBackoffRetry_ListProductQuotasExhausted(t *testing.T) {
 	}
 	tea_util.AssertEqual(t, "Throttling", tea.StringValue(throttlingErr.Code))
 	tea_util.AssertEqual(t, 3, handler.requestCount)
+}
+
+func TestThrottlingDetectedByRetryAfterHeader_NotByErrorCode(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:    "ServiceUnavailable",
+		retryAfterMS: 250,
+		withHeader:   true,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("ListProductQuotas"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/"),
+		Method:      tea.String("POST"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("RPC"),
+		ReqBodyType: tea.String("formData"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{
+		Body: openapiutil.ParseToMap(map[string]interface{}{"ProductCode": tea.String("Ecs")}),
+	}
+	_, _err = client.CallApi(params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok := _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError for x-acs-retry-after, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, "ServiceUnavailable", tea.StringValue(throttlingErr.Code))
+	tea_util.AssertEqual(t, int64(250), tea.Int64Value(throttlingErr.RetryAfter))
+}
+
+func TestThrottlingDetectedByRetryAfterHeader_DoRPCRequestV2(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:    "ServiceUnavailable",
+		retryAfterMS: 180,
+		withHeader:   true,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	config.SignatureAlgorithm = tea.String("v2")
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("ListProductQuotas"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/"),
+		Method:      tea.String("POST"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("RPC"),
+		ReqBodyType: tea.String("formData"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{
+		Body: openapiutil.ParseToMap(map[string]interface{}{"ProductCode": tea.String("Ecs")}),
+	}
+	_, _err = client.CallApi(params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok := _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via DoRPCRequest, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, "ServiceUnavailable", tea.StringValue(throttlingErr.Code))
+	tea_util.AssertEqual(t, int64(180), tea.Int64Value(throttlingErr.RetryAfter))
+}
+
+func TestThrottlingDetectedByRetryAfterHeader_WithCtx(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:    "TooManyRequests",
+		retryAfterMS: 90,
+		withHeader:   true,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("ListProductQuotas"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/"),
+		Method:      tea.String("POST"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("RPC"),
+		ReqBodyType: tea.String("formData"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{
+		Body: openapiutil.ParseToMap(map[string]interface{}{"ProductCode": tea.String("Ecs")}),
+	}
+	_, _err = client.CallApiWithCtx(context.Background(), params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok := _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via CallApiWithCtx, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, "TooManyRequests", tea.StringValue(throttlingErr.Code))
+	tea_util.AssertEqual(t, int64(90), tea.Int64Value(throttlingErr.RetryAfter))
+}
+
+func TestThrottlingDetectedByRetryAfterHeader_DoRPCWithCtxV2(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:    "ServiceUnavailable",
+		retryAfterMS: 70,
+		withHeader:   true,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	config.SignatureAlgorithm = tea.String("v2")
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("ListProductQuotas"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/"),
+		Method:      tea.String("POST"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("RPC"),
+		ReqBodyType: tea.String("formData"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{
+		Body: openapiutil.ParseToMap(map[string]interface{}{"ProductCode": tea.String("Ecs")}),
+	}
+	_, _err = client.CallApiWithCtx(context.Background(), params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok := _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via DoRPCRequestWithCtx, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, int64(70), tea.Int64Value(throttlingErr.RetryAfter))
+}
+
+func TestThrottlingDetectedByRetryAfterHeader_DoROARequest(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:    "ServiceUnavailable",
+		retryAfterMS: 60,
+		withHeader:   true,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	config.SignatureAlgorithm = tea.String("v2")
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("GetFoo"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/foo"),
+		Method:      tea.String("GET"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("ROA"),
+		ReqBodyType: tea.String("json"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{}
+	_, _err = client.CallApi(params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok := _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via DoROARequest, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, int64(60), tea.Int64Value(throttlingErr.RetryAfter))
+
+	_, _err = client.CallApiWithCtx(context.Background(), params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok = _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via DoROARequestWithCtx, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, int64(60), tea.Int64Value(throttlingErr.RetryAfter))
+}
+
+func TestThrottlingDetectedByRetryAfterHeader_DoROAForm(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:    "ServiceUnavailable",
+		retryAfterMS: 55,
+		withHeader:   true,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	config.SignatureAlgorithm = tea.String("v2")
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("PostFoo"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/foo"),
+		Method:      tea.String("POST"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("ROA"),
+		ReqBodyType: tea.String("formData"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{
+		Body: openapiutil.ParseToMap(map[string]interface{}{"ProductCode": tea.String("Ecs")}),
+	}
+	_, _err = client.CallApi(params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok := _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via DoROARequestWithForm, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, int64(55), tea.Int64Value(throttlingErr.RetryAfter))
+
+	_, _err = client.CallApiWithCtx(context.Background(), params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	throttlingErr, ok = _err.(*ThrottlingError)
+	if !ok {
+		t.Fatalf("expected ThrottlingError via DoROAFormRequestWithCtx, got %T: %v", _err, _err)
+	}
+	tea_util.AssertEqual(t, int64(55), tea.Int64Value(throttlingErr.RetryAfter))
+}
+
+func TestNoThrottlingWithoutRetryAfterHeader(t *testing.T) {
+	handler := &retryAfterOnlyMockHandler{
+		errorCode:  "Throttling",
+		withHeader: false,
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	config := CreateConfig()
+	config.Protocol = tea.String("HTTP")
+	config.Endpoint = tea.String(strings.TrimPrefix(server.URL, "http://"))
+	client, _err := NewClient(config)
+	tea_util.AssertNil(t, _err)
+	client.DisableSDKError = tea.Bool(true)
+
+	params := &Params{
+		Action:      tea.String("ListProductQuotas"),
+		Version:     tea.String("2020-05-10"),
+		Protocol:    tea.String("HTTP"),
+		Pathname:    tea.String("/"),
+		Method:      tea.String("POST"),
+		AuthType:    tea.String("AK"),
+		Style:       tea.String("RPC"),
+		ReqBodyType: tea.String("formData"),
+		BodyType:    tea.String("json"),
+	}
+	request := &OpenApiRequest{
+		Body: openapiutil.ParseToMap(map[string]interface{}{"ProductCode": tea.String("Ecs")}),
+	}
+	_, _err = client.CallApi(params, request, CreateRuntimeOptions())
+	tea_util.AssertNotNil(t, _err)
+	if _, ok := _err.(*ThrottlingError); ok {
+		t.Fatalf("did not expect ThrottlingError without x-acs-retry-after, got %T", _err)
+	}
+	if _, ok := _err.(*ClientError); !ok {
+		t.Fatalf("expected ClientError without x-acs-retry-after, got %T", _err)
+	}
 }

--- a/golang/utils/client.go
+++ b/golang/utils/client.go
@@ -129,8 +129,13 @@ func Convert(body interface{}, content interface{}) {
 // @return time left
 func GetThrottlingTimeLeft(headers map[string]*string) (_result *int64) {
 	timeLeft := dara.StringValue(headers["x-acs-retry-after"])
+	if timeLeft == "" {
+		return nil
+	}
 	timeLeftValue, err := strconv.ParseInt(timeLeft, 10, 64)
-	if err != nil {
+	// Only a positive wait time is valid; missing/empty/invalid/<=0 → nil
+	// so callers' IsNil check won't treat 0 as a usable backoff.
+	if err != nil || timeLeftValue <= 0 {
 		return nil
 	}
 	return dara.Int64(timeLeftValue)

--- a/golang/utils/client_test.go
+++ b/golang/utils/client_test.go
@@ -244,7 +244,19 @@ func Test_GetThrottlingTimeLeft(t *testing.T) {
 		"x-acs-retry-after": dara.String("0"),
 	}
 	timeLeft = GetThrottlingTimeLeft(headers)
-	utils.AssertEqual(t, int64(0), dara.Int64Value(timeLeft))
+	utils.AssertNil(t, timeLeft)
+
+	headers = map[string]*string{
+		"x-acs-retry-after": dara.String(""),
+	}
+	timeLeft = GetThrottlingTimeLeft(headers)
+	utils.AssertNil(t, timeLeft)
+
+	headers = map[string]*string{
+		"x-acs-retry-after": dara.String("-1"),
+	}
+	timeLeft = GetThrottlingTimeLeft(headers)
+	utils.AssertNil(t, timeLeft)
 
 	headers = map[string]*string{
 		"x-acs-retry-after": dara.String("invalid"),

--- a/main.tea
+++ b/main.tea
@@ -273,14 +273,15 @@ api doRPCRequest(action: string, version: string, protocol: string, method: stri
     var err = $object(_res);
     var requestId = $default(err.RequestId, err.requestId);
     var code = $default(err.Code, err.code);
-    if (`${code}`.contains('Throttling')) {
+    var retryAfter = OpenApiUtil.getThrottlingTimeLeft(__response.headers);
+    if (!$isNull(retryAfter)) {
       throw new Throttling{
         statusCode = __response.statusCode,
         code = `${code}`,
         message = `code: ${__response.statusCode}, ${$default(err.Message, err.message)} request id: ${requestId}`,
         detail = `${$default(err.Detail, err.detail)}`,
         description = `${$default(err.Description, err.description)}`,
-        retryAfter =  OpenApiUtil.getThrottlingTimeLeft(__response.headers),
+        retryAfter = retryAfter,
         data = err,
         requestId = `${requestId}`,
       };
@@ -484,14 +485,15 @@ api doROARequest(action: string, version: string, protocol: string, method: stri
     var requestId = $string($default(err.RequestId, err.requestId));
     requestId = $string($default(requestId, err.requestid));
     var code = $string($default(err.Code, err.code));
-    if (`${code}`.contains('Throttling')) {
+    var retryAfter = OpenApiUtil.getThrottlingTimeLeft(__response.headers);
+    if (!$isNull(retryAfter)) {
       throw new Throttling{
         statusCode = __response.statusCode,
         code = `${code}`,
         message = `code: ${__response.statusCode}, ${$default(err.Message, err.message)} request id: ${requestId}`,
         detail = `${$default(err.Detail, err.detail)}`,
         description = `${$default(err.Description, err.description)}`,
-        retryAfter =  OpenApiUtil.getThrottlingTimeLeft(__response.headers),
+        retryAfter = retryAfter,
         data = err,
         requestId = `${requestId}`,
       };
@@ -693,14 +695,15 @@ api doROARequestWithForm(action: string, version: string, protocol: string, meth
     var err = $object(_res);
     var requestId = $string($default(err.RequestId, err.requestId));
     var code = $string($default(err.Code, err.code));
-    if (`${code}`.contains('Throttling')) {
+    var retryAfter = OpenApiUtil.getThrottlingTimeLeft(__response.headers);
+    if (!$isNull(retryAfter)) {
       throw new Throttling{
         statusCode = __response.statusCode,
         code = `${code}`,
         message = `code: ${__response.statusCode}, ${$default(err.Message, err.message)} request id: ${requestId}`,
         detail = `${$default(err.Detail, err.detail)}`,
         description = `${$default(err.Description, err.description)}`,
-        retryAfter =  OpenApiUtil.getThrottlingTimeLeft(__response.headers),
+        retryAfter = retryAfter,
         data = err,
         requestId = `${requestId}`,
       };
@@ -960,14 +963,15 @@ api doRequest(params: OpenApiUtil.Params, request: OpenApiUtil.OpenApiRequest, r
     }
     var requestId = $string($default(err.RequestId, err.requestId));
     var code = $string($default(err.Code, err.code));
-    if (`${code}`.contains('Throttling')) {
+    var retryAfter = OpenApiUtil.getThrottlingTimeLeft(__response.headers);
+    if (!$isNull(retryAfter)) {
       throw new Throttling{
         statusCode = __response.statusCode,
         code = `${code}`,
         message = `code: ${__response.statusCode}, ${$default(err.Message, err.message)} request id: ${requestId}`,
         detail = `${$default(err.Detail, err.detail)}`,
         description = `${$default(err.Description, err.description)}`,
-        retryAfter =  OpenApiUtil.getThrottlingTimeLeft(__response.headers),
+        retryAfter = retryAfter,
         data = err,
         requestId = `${requestId}`,
       };

--- a/php/src/OpenApiClient.php
+++ b/php/src/OpenApiClient.php
@@ -453,14 +453,15 @@ class OpenApiClient
           $err = $_res;
           $requestId = (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $code = (@$err['Code'] ? @$err['Code'] : @$err['code']);
-          if (false !== strpos('' . (string)$code . '', 'Throttling')) {
+          $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
+          if (!Dara::isNull($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . (string)$code . '',
               'message' => 'code: ' . (string)$_response->statusCode . ', ' . (string)(@$err['Message'] ? @$err['Message'] : @$err['message']) . ' request id: ' . (string)$requestId . '',
               'detail' => '' . (string)(@$err['Detail'] ? @$err['Detail'] : @$err['detail']) . '',
               'description' => '' . (string)(@$err['Description'] ? @$err['Description'] : @$err['description']) . '',
-              'retryAfter' => Utils::getThrottlingTimeLeft($_response->headers),
+              'retryAfter' => $retryAfter,
               'data' => $err,
               'requestId' => '' . (string)$requestId . '',
             ]);
@@ -709,14 +710,15 @@ class OpenApiClient
           $requestId = '' . (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $requestId = '' . ($requestId ? $requestId : @$err['requestid']);
           $code = '' . (@$err['Code'] ? @$err['Code'] : @$err['code']);
-          if (false !== strpos('' . $code . '', 'Throttling')) {
+          $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
+          if (!Dara::isNull($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . $code . '',
               'message' => 'code: ' . (string)$_response->statusCode . ', ' . (string)(@$err['Message'] ? @$err['Message'] : @$err['message']) . ' request id: ' . $requestId . '',
               'detail' => '' . (string)(@$err['Detail'] ? @$err['Detail'] : @$err['detail']) . '',
               'description' => '' . (string)(@$err['Description'] ? @$err['Description'] : @$err['description']) . '',
-              'retryAfter' => Utils::getThrottlingTimeLeft($_response->headers),
+              'retryAfter' => $retryAfter,
               'data' => $err,
               'requestId' => '' . $requestId . '',
             ]);
@@ -965,14 +967,15 @@ class OpenApiClient
           $err = $_res;
           $requestId = '' . (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $code = '' . (@$err['Code'] ? @$err['Code'] : @$err['code']);
-          if (false !== strpos('' . $code . '', 'Throttling')) {
+          $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
+          if (!Dara::isNull($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . $code . '',
               'message' => 'code: ' . (string)$_response->statusCode . ', ' . (string)(@$err['Message'] ? @$err['Message'] : @$err['message']) . ' request id: ' . $requestId . '',
               'detail' => '' . (string)(@$err['Detail'] ? @$err['Detail'] : @$err['detail']) . '',
               'description' => '' . (string)(@$err['Description'] ? @$err['Description'] : @$err['description']) . '',
-              'retryAfter' => Utils::getThrottlingTimeLeft($_response->headers),
+              'retryAfter' => $retryAfter,
               'data' => $err,
               'requestId' => '' . $requestId . '',
             ]);
@@ -1302,14 +1305,15 @@ class OpenApiClient
 
           $requestId = '' . (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $code = '' . (@$err['Code'] ? @$err['Code'] : @$err['code']);
-          if (false !== strpos('' . $code . '', 'Throttling')) {
+          $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
+          if (!Dara::isNull($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . $code . '',
               'message' => 'code: ' . (string)$_response->statusCode . ', ' . (string)(@$err['Message'] ? @$err['Message'] : @$err['message']) . ' request id: ' . $requestId . '',
               'detail' => '' . (string)(@$err['Detail'] ? @$err['Detail'] : @$err['detail']) . '',
               'description' => '' . (string)(@$err['Description'] ? @$err['Description'] : @$err['description']) . '',
-              'retryAfter' => Utils::getThrottlingTimeLeft($_response->headers),
+              'retryAfter' => $retryAfter,
               'data' => $err,
               'requestId' => '' . $requestId . '',
             ]);

--- a/php/src/OpenApiClient.php
+++ b/php/src/OpenApiClient.php
@@ -454,7 +454,7 @@ class OpenApiClient
           $requestId = (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $code = (@$err['Code'] ? @$err['Code'] : @$err['code']);
           $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
-          if (!Dara::isNull($retryAfter)) {
+          if (!is_null($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . (string)$code . '',
@@ -711,7 +711,7 @@ class OpenApiClient
           $requestId = '' . ($requestId ? $requestId : @$err['requestid']);
           $code = '' . (@$err['Code'] ? @$err['Code'] : @$err['code']);
           $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
-          if (!Dara::isNull($retryAfter)) {
+          if (!is_null($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . $code . '',
@@ -968,7 +968,7 @@ class OpenApiClient
           $requestId = '' . (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $code = '' . (@$err['Code'] ? @$err['Code'] : @$err['code']);
           $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
-          if (!Dara::isNull($retryAfter)) {
+          if (!is_null($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . $code . '',
@@ -1306,7 +1306,7 @@ class OpenApiClient
           $requestId = '' . (@$err['RequestId'] ? @$err['RequestId'] : @$err['requestId']);
           $code = '' . (@$err['Code'] ? @$err['Code'] : @$err['code']);
           $retryAfter = Utils::getThrottlingTimeLeft($_response->headers);
-          if (!Dara::isNull($retryAfter)) {
+          if (!is_null($retryAfter)) {
             throw new ThrottlingException([
               'statusCode' => $_response->statusCode,
               'code' => '' . $code . '',

--- a/php/src/Utils.php
+++ b/php/src/Utils.php
@@ -115,28 +115,6 @@ class Utils
   }
 
 
-  private static function getTimeLeft($rateLimit)
-  {
-    if ($rateLimit) {
-      $pairs = explode(',', $rateLimit);
-      foreach ($pairs as $pair) {
-        $kv = explode(':', $pair);
-        if (count($kv) === 2) {
-          $key = trim($kv[0]);
-          $value = trim($kv[1]);
-          if ($key === 'TimeLeft') {
-            $timeLeftValue = intval($value);
-            if ($timeLeftValue === 0 && $value !== "0") { // 确认不是 "0"
-              return null;
-            }
-            return $timeLeftValue;
-          }
-        }
-      }
-    }
-    return null;
-  }
-
   /**
    * @remarks
    * Hash the raw data with signatureAlgorithm

--- a/php/src/Utils.php
+++ b/php/src/Utils.php
@@ -102,10 +102,16 @@ class Utils
     if (is_array($retryAfter)) {
       $retryAfter = $retryAfter[0];
     }
-    if (null === $retryAfter || !is_numeric($retryAfter)) {
+    if (null === $retryAfter || '' === $retryAfter || !is_numeric($retryAfter)) {
       return null;
     }
-    return intval($retryAfter);
+    $timeLeft = intval($retryAfter);
+    // Only a positive wait time is valid; missing/empty/invalid/<=0 → null
+    // so callers' isNull check won't treat 0 as a usable backoff.
+    if ($timeLeft <= 0) {
+      return null;
+    }
+    return $timeLeft;
   }
 
 

--- a/php/tests/UtilsTest.php
+++ b/php/tests/UtilsTest.php
@@ -60,10 +60,18 @@ class UtilsTest extends TestCase
         $timeLeft = Utils::getThrottlingTimeLeft($headers);
         $this->assertNull($timeLeft);
 
-        // Test with zero retry-after
+        // Zero / empty / negative are not usable backoff values
         $headers = array('x-acs-retry-after' => '0');
         $timeLeft = Utils::getThrottlingTimeLeft($headers);
-        $this->assertEquals(0, $timeLeft);
+        $this->assertNull($timeLeft);
+
+        $headers = array('x-acs-retry-after' => '');
+        $timeLeft = Utils::getThrottlingTimeLeft($headers);
+        $this->assertNull($timeLeft);
+
+        $headers = array('x-acs-retry-after' => '-1');
+        $timeLeft = Utils::getThrottlingTimeLeft($headers);
+        $this->assertNull($timeLeft);
 
         // Test with invalid value
         $headers = array('x-acs-retry-after' => 'Invalid');

--- a/python/alibabacloud_tea_openapi/client.py
+++ b/python/alibabacloud_tea_openapi/client.py
@@ -282,14 +282,15 @@ class Client:
                     err = _res
                     request_id = err.get("RequestId") or err.get("requestId")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -500,14 +501,15 @@ class Client:
                     err = _res
                     request_id = err.get("RequestId") or err.get("requestId")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -721,14 +723,15 @@ class Client:
                     request_id = err.get("RequestId") or err.get("requestId")
                     request_id = request_id or err.get("requestid")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -927,14 +930,15 @@ class Client:
                     request_id = err.get("RequestId") or err.get("requestId")
                     request_id = request_id or err.get("requestid")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -1148,14 +1152,15 @@ class Client:
                     err = _res
                     request_id = err.get("RequestId") or err.get("requestId")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -1354,14 +1359,15 @@ class Client:
                     err = _res
                     request_id = err.get("RequestId") or err.get("requestId")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -1657,14 +1663,15 @@ class Client:
 
                     request_id = err.get("RequestId") or err.get("requestId")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )
@@ -1893,14 +1900,15 @@ class Client:
 
                     request_id = err.get("RequestId") or err.get("requestId")
                     code = err.get("Code") or err.get("code")
-                    if 'Throttling' in f'{code}':
+                    retry_after = Utils.get_throttling_time_left(_response.headers)
+                    if not DaraCore.is_null(retry_after):
                         raise main_exceptions.ThrottlingException(
                             status_code = _response.status_code,
                             code = f'{code}',
                             message = f'code: {_response.status_code}, {err.get("Message") or err.get("message")} request id: {request_id}',
                             detail = f'{err.get("Detail") or err.get("detail")}',
                             description = f'{err.get("Description") or err.get("description")}',
-                            retry_after = Utils.get_throttling_time_left(_response.headers),
+                            retry_after = retry_after,
                             data = err,
                             request_id = f'{request_id}'
                         )

--- a/python/alibabacloud_tea_openapi/utils.py
+++ b/python/alibabacloud_tea_openapi/utils.py
@@ -566,10 +566,17 @@ class Utils(object):
     @staticmethod
     def get_throttling_time_left(headers: Dict[str, str]) -> int:
         retry_after = headers.get('x-acs-retry-after')
+        if retry_after is None or retry_after == '':
+            return None
         try:
-            return int(retry_after)
+            time_left = int(retry_after)
         except (TypeError, ValueError):
             return None
+        # Only a positive wait time is valid; missing/empty/invalid/<=0 → None
+        # so callers' is_null check won't treat 0 as a usable backoff.
+        if time_left <= 0:
+            return None
+        return time_left
 
     @staticmethod
     def _get_time_left(rate_limit: str) -> int:

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -525,3 +525,12 @@ class TestUtils(unittest.TestCase):
         flat_model_list = Client.map_to_flat_style(model_list)
         self.assertEqual("test2", flat_model_list[0].requestId)
         self.assertEqual("value2", flat_model_list[0].dic["#4#key2"])
+
+    def test_get_throttling_time_left(self):
+        self.assertEqual(2000, Client.get_throttling_time_left({'x-acs-retry-after': '2000'}))
+        self.assertIsNone(Client.get_throttling_time_left({'x-acs-retry-after': '0'}))
+        self.assertIsNone(Client.get_throttling_time_left({'x-acs-retry-after': ''}))
+        self.assertIsNone(Client.get_throttling_time_left({'x-acs-retry-after': '-1'}))
+        self.assertIsNone(Client.get_throttling_time_left({'x-acs-retry-after': 'invalid'}))
+        self.assertIsNone(Client.get_throttling_time_left({}))
+

--- a/ts/src/client.ts
+++ b/ts/src/client.ts
@@ -302,14 +302,15 @@ export default class Client {
           let err = _res;
           let requestId = err["RequestId"] || err["requestId"];
           let code = err["Code"] || err["code"];
-          if (`${code}`.includes("Throttling")) {
+          let retryAfter = OpenApiUtil.getThrottlingTimeLeft(response_.headers);
+          if (!$dara.isNull(retryAfter)) {
             throw new $_error.ThrottlingError({
               statusCode: response_.statusCode,
               code: `${code}`,
               message: `code: ${response_.statusCode}, ${err["Message"] || err["message"]} request id: ${requestId}`,
               detail: `${err["Detail"] || err["detail"]}`,
               description: `${err["Description"] || err["description"]}`,
-              retryAfter: OpenApiUtil.getThrottlingTimeLeft(response_.headers),
+              retryAfter: retryAfter,
               data: err,
               requestId: `${requestId}`,
             });
@@ -560,14 +561,15 @@ export default class Client {
           let requestId = err["RequestId"] || err["requestId"];
           requestId = requestId || err["requestid"];
           let code = err["Code"] || err["code"];
-          if (`${code}`.includes("Throttling")) {
+          let retryAfter = OpenApiUtil.getThrottlingTimeLeft(response_.headers);
+          if (!$dara.isNull(retryAfter)) {
             throw new $_error.ThrottlingError({
               statusCode: response_.statusCode,
               code: `${code}`,
               message: `code: ${response_.statusCode}, ${err["Message"] || err["message"]} request id: ${requestId}`,
               detail: `${err["Detail"] || err["detail"]}`,
               description: `${err["Description"] || err["description"]}`,
-              retryAfter: OpenApiUtil.getThrottlingTimeLeft(response_.headers),
+              retryAfter: retryAfter,
               data: err,
               requestId: `${requestId}`,
             });
@@ -818,14 +820,15 @@ export default class Client {
           let err = _res;
           let requestId = err["RequestId"] || err["requestId"];
           let code = err["Code"] || err["code"];
-          if (`${code}`.includes("Throttling")) {
+          let retryAfter = OpenApiUtil.getThrottlingTimeLeft(response_.headers);
+          if (!$dara.isNull(retryAfter)) {
             throw new $_error.ThrottlingError({
               statusCode: response_.statusCode,
               code: `${code}`,
               message: `code: ${response_.statusCode}, ${err["Message"] || err["message"]} request id: ${requestId}`,
               detail: `${err["Detail"] || err["detail"]}`,
               description: `${err["Description"] || err["description"]}`,
-              retryAfter: OpenApiUtil.getThrottlingTimeLeft(response_.headers),
+              retryAfter: retryAfter,
               data: err,
               requestId: `${requestId}`,
             });
@@ -1168,14 +1171,15 @@ export default class Client {
 
           let requestId = err["RequestId"] || err["requestId"];
           let code = err["Code"] || err["code"];
-          if (`${code}`.includes("Throttling")) {
+          let retryAfter = OpenApiUtil.getThrottlingTimeLeft(response_.headers);
+          if (!$dara.isNull(retryAfter)) {
             throw new $_error.ThrottlingError({
               statusCode: response_.statusCode,
               code: `${code}`,
               message: `code: ${response_.statusCode}, ${err["Message"] || err["message"]} request id: ${requestId}`,
               detail: `${err["Detail"] || err["detail"]}`,
               description: `${err["Description"] || err["description"]}`,
-              retryAfter: OpenApiUtil.getThrottlingTimeLeft(response_.headers),
+              retryAfter: retryAfter,
               data: err,
               requestId: `${requestId}`,
             });

--- a/ts/src/utils.ts
+++ b/ts/src/utils.ts
@@ -734,8 +734,13 @@ export default class Client {
    */
   static getThrottlingTimeLeft(headers: {[key: string ]: string}): number | undefined { 
     const retryAfter = headers["x-acs-retry-after"];
+    if (retryAfter === undefined || retryAfter === null || retryAfter === "") {
+      return undefined;
+    }
     const timeLeftValue = parseInt(retryAfter, 10);
-    if (Number.isNaN(timeLeftValue)) {
+    // Only a positive wait time is valid; missing/empty/invalid/<=0 → undefined
+    // so callers' !$isNull(retryAfter) won't treat 0 as a usable backoff.
+    if (Number.isNaN(timeLeftValue) || timeLeftValue <= 0) {
       return undefined;
     }
     return timeLeftValue;

--- a/ts/test/util.spec.ts
+++ b/ts/test/util.spec.ts
@@ -690,4 +690,13 @@ describe('Tea Util', function () {
     assert.strictEqual(flatModelList[0].requestId, 'test2');
     assert.strictEqual(flatModelList[0].dict['#4#key2'], 'value2');
   });
+
+  it('getThrottlingTimeLeft should only return positive wait times', function () {
+    assert.strictEqual(Client.getThrottlingTimeLeft({ 'x-acs-retry-after': '2000' }), 2000);
+    assert.strictEqual(Client.getThrottlingTimeLeft({ 'x-acs-retry-after': '0' }), undefined);
+    assert.strictEqual(Client.getThrottlingTimeLeft({ 'x-acs-retry-after': '' }), undefined);
+    assert.strictEqual(Client.getThrottlingTimeLeft({ 'x-acs-retry-after': '-1' }), undefined);
+    assert.strictEqual(Client.getThrottlingTimeLeft({ 'x-acs-retry-after': 'invalid' }), undefined);
+    assert.strictEqual(Client.getThrottlingTimeLeft({}), undefined);
+  });
 });


### PR DESCRIPTION
## Summary
- Treat HTTP errors with `x-acs-retry-after` as throttling (no longer require Code to contain `Throttling`).
- Align main.tea and generated multi-language clients (Go/Python/TS/PHP/C#/C++).
- Add unit tests covering header-based detection across RPC/ROA/context paths.