### PR TITLE
fix(php): sync exception code to errCode for throttling retry

### DIFF
--- a/php/src/Exceptions/AlibabaCloudException.php
+++ b/php/src/Exceptions/AlibabaCloudException.php
@@ -35,8 +35,14 @@ class AlibabaCloudException extends DaraException
 
   public function __construct($map)
   {
+    // Dara::shouldRetry / getBackoffDelay match on getErrCode()/getName(),
+    // while OpenAPI exceptions store the business error code in `code`.
+    // Sync code → errCode so throttling (and other) retry conditions can hit.
     if (isset($map['code']) && !isset($map['errCode'])) {
       $map['errCode'] = $map['code'];
+    }
+    if (!isset($map['name'])) {
+      $map['name'] = 'AlibabaCloudException';
     }
     parent::__construct($map);
     $this->statusCode = $map['statusCode'];

--- a/php/src/Exceptions/ClientException.php
+++ b/php/src/Exceptions/ClientException.php
@@ -13,6 +13,7 @@ class ClientException extends AlibabaCloudException
 
   public function __construct($map)
   {
+    $map['name'] = 'ClientException';
     parent::__construct($map);
     $this->accessDeniedDetail = $map['accessDeniedDetail'];
   }

--- a/php/src/Exceptions/ServerException.php
+++ b/php/src/Exceptions/ServerException.php
@@ -9,6 +9,7 @@ class ServerException extends AlibabaCloudException
 
   public function __construct($map)
   {
+    $map['name'] = 'ServerException';
     parent::__construct($map);
   }
 }

--- a/php/src/OpenApiClient.php
+++ b/php/src/OpenApiClient.php
@@ -1726,6 +1726,8 @@ class OpenApiClient
         'event' => $event,
       ]);
     }
+    // Generator completes without explicit return (PHP 5.6 compatible)
+    return;
   }
 
   /**

--- a/php/tests/ExceptionRetryMatchTest.php
+++ b/php/tests/ExceptionRetryMatchTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Darabonba\OpenApi\Tests;
+
+use AlibabaCloud\Dara\Dara;
+use AlibabaCloud\Dara\RetryPolicy\RetryCondition;
+use AlibabaCloud\Dara\RetryPolicy\RetryOptions;
+use AlibabaCloud\Dara\RetryPolicy\RetryPolicyContext;
+use Darabonba\OpenApi\Exceptions\AlibabaCloudException;
+use Darabonba\OpenApi\Exceptions\ClientException;
+use Darabonba\OpenApi\Exceptions\ServerException;
+use Darabonba\OpenApi\Exceptions\ThrottlingException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression: OpenAPI exceptions must expose errCode/name so Dara::shouldRetry
+ * can match retryCondition.errorCode after the first attempt (retryCount > 0).
+ *
+ * @internal
+ * @covers \Darabonba\OpenApi\Exceptions\AlibabaCloudException
+ * @covers \Darabonba\OpenApi\Exceptions\ThrottlingException
+ * @covers \Darabonba\OpenApi\Exceptions\ClientException
+ * @covers \Darabonba\OpenApi\Exceptions\ServerException
+ */
+class ExceptionRetryMatchTest extends TestCase
+{
+    private static function baseMap(array $extra = [])
+    {
+        return array_merge([
+            'statusCode' => 400,
+            'code' => 'Throttling',
+            'message' => 'code: 400, Throttling request id: rid',
+            'description' => '',
+            'requestId' => 'rid',
+            'data' => ['Code' => 'Throttling'],
+        ], $extra);
+    }
+
+    private static function throttlingRetryOptions()
+    {
+        return new RetryOptions([
+            'retryable' => true,
+            'maxAttempts' => 3,
+            'retryCondition' => [new RetryCondition([
+                'maxAttempts' => 3,
+                'errorCode' => ['Throttling', 'Throttling.User', 'Throttling.Api'],
+                'maxDelay' => 60000,
+            ])],
+        ]);
+    }
+
+    public function testAlibabaCloudExceptionSyncsCodeToErrCodeAndDefaultName()
+    {
+        $ex = new AlibabaCloudException(self::baseMap([
+            'detail' => 'throttled',
+            'description' => 'slow down',
+        ]));
+        $this->assertEquals('Throttling', $ex->code);
+        $this->assertEquals('Throttling', $ex->getErrCode());
+        $this->assertEquals('AlibabaCloudException', $ex->getName());
+        $this->assertEquals(400, $ex->getStatusCode());
+        $this->assertEquals('throttled', $ex->getDetail());
+        $this->assertEquals('slow down', $ex->getDescription());
+        $this->assertEquals('rid', $ex->getRequestId());
+    }
+
+    public function testAlibabaCloudExceptionPreservesExplicitErrCodeAndName()
+    {
+        $ex = new AlibabaCloudException(self::baseMap([
+            'code' => 'Throttling',
+            'errCode' => 'CustomErr',
+            'name' => 'CustomName',
+        ]));
+        $this->assertEquals('Throttling', $ex->code);
+        $this->assertEquals('CustomErr', $ex->getErrCode());
+        $this->assertEquals('CustomName', $ex->getName());
+    }
+
+    public function testThrottlingExceptionErrCodeMatchesShouldRetryAfterFirstAttempt()
+    {
+        $ex = new ThrottlingException(self::baseMap([
+            'retryAfter' => 1000,
+        ]));
+        $this->assertEquals('Throttling', $ex->getErrCode());
+        $this->assertEquals('ThrottlingException', $ex->getName());
+        $this->assertEquals(1000, $ex->getRetryAfter());
+
+        $options = self::throttlingRetryOptions();
+        // First attempt always allowed.
+        $ctx0 = new RetryPolicyContext([
+            'retriesAttempted' => 0,
+            'exception' => $ex,
+        ]);
+        $this->assertTrue(Dara::shouldRetry($options, $ctx0));
+
+        // Second attempt must match errorCode via getErrCode() (was broken when only `code` was set).
+        $ctx1 = new RetryPolicyContext([
+            'retriesAttempted' => 1,
+            'exception' => $ex,
+        ]);
+        $this->assertTrue(Dara::shouldRetry($options, $ctx1));
+        $this->assertEquals(1000, Dara::getBackoffDelay($options, $ctx1));
+    }
+
+    public function testThrottlingUserApiErrorCodesAlsoMatch()
+    {
+        $options = self::throttlingRetryOptions();
+        foreach (['Throttling.User', 'Throttling.Api'] as $code) {
+            $ex = new ThrottlingException(self::baseMap([
+                'code' => $code,
+                'retryAfter' => 500,
+            ]));
+            $ctx = new RetryPolicyContext([
+                'retriesAttempted' => 1,
+                'exception' => $ex,
+            ]);
+            $this->assertTrue(Dara::shouldRetry($options, $ctx), "should retry for code=$code");
+            $this->assertEquals(500, Dara::getBackoffDelay($options, $ctx));
+        }
+    }
+
+    public function testUnmatchedErrorCodeDoesNotRetryAfterFirstAttempt()
+    {
+        $ex = new ThrottlingException(self::baseMap([
+            'code' => 'InvalidParameter',
+            'retryAfter' => 1000,
+        ]));
+        $options = self::throttlingRetryOptions();
+        $ctx = new RetryPolicyContext([
+            'retriesAttempted' => 1,
+            'exception' => $ex,
+        ]);
+        $this->assertFalse(Dara::shouldRetry($options, $ctx));
+    }
+
+    public function testClientAndServerExceptionSetLogicalNames()
+    {
+        $client = new ClientException(self::baseMap([
+            'code' => 'Forbidden.RAM',
+            'accessDeniedDetail' => ['foo' => 'bar'],
+        ]));
+        $this->assertEquals('ClientException', $client->getName());
+        $this->assertEquals('Forbidden.RAM', $client->getErrCode());
+        $this->assertEquals(['foo' => 'bar'], $client->getAccessDeniedDetail());
+
+        $server = new ServerException(self::baseMap([
+            'statusCode' => 500,
+            'code' => 'InternalError',
+        ]));
+        $this->assertEquals('ServerException', $server->getName());
+        $this->assertEquals('InternalError', $server->getErrCode());
+    }
+}

--- a/php/tests/Mock/MockServer.php
+++ b/php/tests/Mock/MockServer.php
@@ -6,6 +6,37 @@ if (!$server) {
     die("Error: $errstr ($errno)");
 }
 
+/**
+ * Read a full HTTP/1.1 request (headers + Content-Length body).
+ * ACS3-signed requests often exceed 1024 bytes; a single fread is flaky on CI.
+ */
+function readHttpRequest($client)
+{
+    $request = '';
+    while (!feof($client)) {
+        $chunk = fread($client, 8192);
+        if ($chunk === false || $chunk === '') {
+            break;
+        }
+        $request .= $chunk;
+        $headerEnd = strpos($request, "\r\n\r\n");
+        if ($headerEnd === false) {
+            continue;
+        }
+        if (preg_match('/Content-Length:\s*(\d+)/i', $request, $matches)) {
+            $bodyLength = (int) $matches[1];
+            $bodyStart = $headerEnd + 4;
+            if (strlen($request) - $bodyStart >= $bodyLength) {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    return $request;
+}
+
 function send_sse($client, $id, $event, $data, $retry = 3000)
 {
     $sseData = "id: $id\n";
@@ -18,9 +49,16 @@ function send_sse($client, $id, $event, $data, $retry = 3000)
 }
 
 while ($client = @stream_socket_accept($server)) {
-    // 读取请求
-    $request = fread($client, 1024);
-    list($headers, $body) = explode("\r\n\r\n", $request, 2);
+    stream_set_timeout($client, 5);
+    $request = readHttpRequest($client);
+    if ($request === '') {
+        fclose($client);
+        continue;
+    }
+
+    $parts = explode("\r\n\r\n", $request, 2);
+    $headers = $parts[0];
+    $body = isset($parts[1]) ? $parts[1] : '';
     // 简单解析请求头
     $headerLines = explode("\r\n", $headers);
     $requestLine = array_shift($headerLines);
@@ -28,6 +66,10 @@ while ($client = @stream_socket_accept($server)) {
     preg_match('/\b(bodytype):[ ]*([\w\d]+)\b/i', $headers, $bodyTypeMatch);
     $bodyType = isset($bodyTypeMatch[2]) ? $bodyTypeMatch[2] : null;
     preg_match('/^(GET|POST|PUT|DELETE)\s(\/\S*)\sHTTP\/1.1/', $requestLine, $matches);
+    if (count($matches) < 3) {
+        fclose($client);
+        continue;
+    }
     $method = $matches[1];
     $path = $matches[2];
 
@@ -35,6 +77,9 @@ while ($client = @stream_socket_accept($server)) {
     $headerAssoc = [];
 
     foreach ($headerLines as $header) {
+        if (strpos($header, ': ') === false) {
+            continue;
+        }
         list($name, $value) = explode(": ", $header, 2);
         $headerAssoc[strtolower($name)] = $value;
     }
@@ -43,13 +88,17 @@ while ($client = @stream_socket_accept($server)) {
             "Content-Type: text/event-stream;charset=UTF-8\r\n" .
             "Cache-Control: no-cache\r\n" .
             "Connection: keep-alive\r\n";
+        // Echo request headers for assertions, but never override SSE framing headers.
+        $skipEcho = array('content-type' => true, 'connection' => true, 'cache-control' => true, 'host' => true, 'content-length' => true);
         foreach ($headerAssoc as $name => $value) {
+            if (isset($skipEcho[$name])) {
+                continue;
+            }
             $responseHeaders .= $name . ": " . $value . "\r\n";
         }
         $responseHeaders .= "\r\n";
         fwrite($client, $responseHeaders);
-        // 刷新缓冲区，确保头部被立刻发送
-        flush();
+        fflush($client);
 
         // 模拟发送事件流
         $count = 0;
@@ -57,14 +106,7 @@ while ($client = @stream_socket_accept($server)) {
             $data = [
                 "count" => $count
             ];
-            $sseData = "id: sse-test\n";
-            $sseData .= "event: flow\n";
-            $sseData .= "data: " . json_encode($data) . "\n";
-            $sseData .= "retry: 3000\n\n"; // 重试时间可选
-            fwrite($client, $sseData);
-
-            // 再次刷新缓冲区，以确保数据被发送
-            flush();
+            send_sse($client, 'sse-test', 'flow', $data, 3000);
 
             // 等待100毫秒
             usleep(100000);
@@ -81,18 +123,8 @@ while ($client = @stream_socket_accept($server)) {
             "Content-Type: text/plain\r\n" .
             "Connection: close\r\n\r\n";
         fwrite($client, $responseHeaders . "Server Timeout");
+        fflush($client);
     } else {
-        $headerAssoc = [];
-        foreach ($headerLines as $headerLine) {
-            list($key, $value) = explode(': ', $headerLine, 2);
-            $headerAssoc[strtolower($key)] = trim($value);
-        }
-
-        // 获取路径和请求方法
-        preg_match('/^(GET|POST|PUT|DELETE)\s(\/\S*)\sHTTP\/1.1/', $requestLine, $matches);
-        $method = $matches[1];
-        $path = $matches[2];
-
         // 构建响应头
         $responseHeaders = "HTTP/1.1 200 OK\r\n" .
             "Connection: close\r\n" .
@@ -104,8 +136,6 @@ while ($client = @stream_socket_accept($server)) {
 
         // 构建响应体
         $responseBody = "";
-
-        echo $bodyType . "\n";
 
         switch ($bodyType) {
             case 'array':
@@ -166,6 +196,7 @@ while ($client = @stream_socket_accept($server)) {
         }
 
         fwrite($client, $responseHeaders . "\r\n" . $responseBody);
+        fflush($client);
     }
     fclose($client);
     continue;

--- a/php/tests/OpenApiClientTest.php
+++ b/php/tests/OpenApiClientTest.php
@@ -104,16 +104,18 @@ class OpenApiClientTest extends TestCase
     private static function getResponseHeader($headers, $name)
     {
         $key = strtolower($name);
-        if (!isset($headers[$key])) {
-            return null;
+        foreach ($headers as $headerName => $value) {
+            if (strtolower($headerName) !== $key) {
+                continue;
+            }
+            if (is_array($value)) {
+                return $value[0];
+            }
+
+            return $value;
         }
 
-        $value = $headers[$key];
-        if (is_array($value)) {
-            return $value[0];
-        }
-
-        return $value;
+        return null;
     }
 
     public static function stopThrottlingMockServer()
@@ -194,19 +196,40 @@ class OpenApiClientTest extends TestCase
      */
     private static function ensureMockServer()
     {
-        if (self::$serverStarted) {
+        if (self::$serverStarted && self::isMockServerReady()) {
             return;
         }
+
+        self::stopMockServer();
+
         // 启动 Mock 服务器
         $server = __DIR__ . '/Mock/MockServer.php';
         $command = "php " . escapeshellarg($server) . " > /dev/null 2>&1 & echo $!";
         $output = shell_exec($command);
         self::$serverPid = (int)trim($output);
-        self::$serverStarted = true;
-        // 等待服务器启动并验证
-        sleep(2); // 增加等待时间确保服务器完全启动
-        // 注册关闭钩子
-        register_shutdown_function(array(__CLASS__, 'stopMockServer'));
+
+        $deadline = microtime(true) + 10;
+        while (microtime(true) < $deadline) {
+            if (self::isMockServerReady()) {
+                self::$serverStarted = true;
+                register_shutdown_function(array(__CLASS__, 'stopMockServer'));
+                return;
+            }
+            usleep(100000);
+        }
+
+        self::stopMockServer();
+        throw new \RuntimeException('Failed to start mock server on 127.0.0.1:8000');
+    }
+
+    private static function isMockServerReady()
+    {
+        $connection = @fsockopen('127.0.0.1', 8000, $errno, $errstr, 0.2);
+        if ($connection === false) {
+            return false;
+        }
+        fclose($connection);
+        return true;
     }
 
     /**
@@ -214,10 +237,11 @@ class OpenApiClientTest extends TestCase
      */
     public static function stopMockServer()
     {
-        if (self::$serverStarted && self::$serverPid > 0) {
-            shell_exec('kill ' . self::$serverPid);
-            self::$serverStarted = false;
+        if (self::$serverPid > 0) {
+            shell_exec('kill ' . self::$serverPid . ' 2>/dev/null');
+            self::$serverPid = 0;
         }
+        self::$serverStarted = false;
     }
 
     /**
@@ -629,9 +653,6 @@ class OpenApiClientTest extends TestCase
     {
         self::ensureMockServer();
 
-        // 额外等待确保 Mock 服务器完全启动 (for CI environments)
-        usleep(500000); // 0.5秒
-
         $config = self::createConfig();
         $runtime = self::createRuntimeOptions();
         $config->protocol = "HTTP";
@@ -659,15 +680,15 @@ class OpenApiClientTest extends TestCase
         foreach ($response as $event) {
             $this->assertEquals(200, $event->statusCode);
             $headers = $event->headers;
-            $this->assertEquals('text/event-stream;charset=UTF-8', $headers['Content-Type'][0]);
-            $this->assertEquals('sdk', $headers['for-test'][0]);
-            $userAgentArray = explode(' ', $headers['user-agent'][0]);
+            $this->assertEquals('text/event-stream;charset=UTF-8', self::getResponseHeader($headers, 'Content-Type'));
+            $this->assertEquals('sdk', self::getResponseHeader($headers, 'for-test'));
+            $userAgentArray = explode(' ', self::getResponseHeader($headers, 'user-agent'));
             $this->assertEquals('config.userAgent', end($userAgentArray));
-            $this->assertEquals('global-value', $headers['global-key'][0]);
-            $this->assertEquals('extends-value', $headers['extends-key'][0]);
-            $this->assertNotEmpty($headers['x-acs-signature-nonce'][0]);
-            $this->assertNotEmpty($headers['x-acs-date'][0]);
-            $this->assertEquals('application/json', $headers['accept'][0]);
+            $this->assertEquals('global-value', self::getResponseHeader($headers, 'global-key'));
+            $this->assertEquals('extends-value', self::getResponseHeader($headers, 'extends-key'));
+            $this->assertNotEmpty(self::getResponseHeader($headers, 'x-acs-signature-nonce'));
+            $this->assertNotEmpty(self::getResponseHeader($headers, 'x-acs-date'));
+            $this->assertEquals('application/json', self::getResponseHeader($headers, 'accept'));
             $event = $event->event->toArray();
             // var_dump($event);
             $events[] = json_decode($event['data'], true);


### PR DESCRIPTION
## Summary
- PHP OpenAPI exceptions now sync `code` → `errCode` and set logical `name` so `Dara::shouldRetry` can match throttling retry conditions after the first attempt.
- Align `ClientException` / `ServerException` names with other languages; add regression tests for errCode matching and backoff.